### PR TITLE
Enable use of ADC2

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,9 +1,23 @@
 menu "ATOMVM_ADC Configuration"
 
-config AVM_ADC_ENABLE
-	bool  "Enable AtomVM ADC driver"
-	default y
-	help
-		Use this parameter to enable or disable the AtomVM ADC driver.
+    config AVM_ADC_ENABLE
+	    bool "Enable AtomVM ADC driver"
+	    default y
+	    help
+		    Use this parameter to enable or disable the AtomVM ADC driver.
+
+    config AVM_ADC2_ENABLE
+        depends on AVM_ADC_ENABLE
+        bool "Enable ADC Unit 2"
+        default n
+        help
+            This will allow using both ADC units.
+
+            ADC2 is used by the Wi-Fi driver. The application can only use ADC2 when the
+            wifi driver is not in use. If you need to use wifi in your AtomVM application
+            first use adc:wifi_acquire/0 to stop adc2 after the current conversion (if any)
+            before starting wifi. This will block any attempts to read adc2 until the
+            application uses adc:wifi_release/0 to stop the wifi driver and free the adc2
+            unit for other tasks.
 
 endmenu

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@ This AtomVM Nif and Erlang library can be used to read ADC pins on the ESP32 SoC
 
 This Nif is included as an add-on to the AtomVM base image.  In order to use this Nif in your AtomVM program, you must be able to build the AtomVM virtual machine, which in turn requires installation of the Espressif IDF SDK and tool chain.
 
-> Note.  Currently, this Nif only supports the IDF SDK ADC1 interface, which provides 8 channels (GPIOs 32-39).  There is currently no support for the ADC2 interface.
+The driver supports both adc interfaces. ADC1 is enabled by default, and unlike the limitation of Espressif's ESP-IDF you can set a different bit with for each channel on ADC1. To use ADC2 it must be enabled in the esp-idf menuconfig setting ```Component config -> ATOMVM_ADC Configuration``` menu. ADC1 can be used freely but ADC2 is used by the Wi-Fi module, and it cannot be used for adc tasks while wifi is active. To ensure that wifi is not interfered with you should use `adc:wifi_acquire/0` before you start the wifi in your application. Wi-Fi can then be stopped by using `adc:wifi_release/0` and you will the be free to use adc2 for reading voltages from adc2. You will need to start the pins (with optional configurations) again before reading, because all of the adc2 processes are stopped when using adc:wifi_acquire.
 
-For more information about the Analog Digital Converter on the ESP32, see the [IDF SDK Documentation](https://docs.espressif.com/projects/esp-idf/en/v3.3.4/api-reference/peripherals/adc.html)
+> Note. Some boards use some of the adc2 pins for other purposes, `ESP-WROVER-KIT: GPIOs 0, 2, 4 and 15`, and `ESP32 DevKitC: GPIO 0` are just two examples. Check the documentation for your board, as always!
+
+* ADC1 pins
+    - GPIOs 32-39
+* ADC2 pins
+    - GPIOs 0, 2, 4, 12-15, 25-27
+
+
+For more information about the Analog Digital Converter on the ESP32, see the [IDF SDK Documentation](https://docs.espressif.com/projects/esp-idf/en/v4.4.2/api-reference/peripherals/adc.html)
 
 Documentation for this component can be found in the following sections:
 

--- a/nifs/atomvm_adc.c
+++ b/nifs/atomvm_adc.c
@@ -51,6 +51,7 @@
 // https://docs.espressif.com/projects/esp-idf/en/v4.4.2/api-reference/peripherals/adc.html
 //
 
+#if CONFIG_IDF_TARGET_ESP32
 static const char *const bit_9_atom           = "\x5"  "bit_9";
 static const char *const bit_10_atom          = "\x6"  "bit_10";
 static const char *const bit_11_atom          = "\x6"  "bit_11";
@@ -76,13 +77,15 @@ static const char *const timeout_atom         = "\x7"  "timeout";
 
 static adc_bits_width_t get_width(Context *ctx, term width)
 {
+    #if CONFIG_IDF_TARGET_ESP32
     if (width == context_make_atom(ctx, bit_9_atom)) {
         return ADC_WIDTH_BIT_9;
     } else if (width == context_make_atom(ctx, bit_10_atom)) {
         return ADC_WIDTH_BIT_10;
     } else if (width == context_make_atom(ctx, bit_11_atom)) {
         return ADC_WIDTH_BIT_11;
-    } else if (width == context_make_atom(ctx, bit_12_atom)) {
+    } else
+    if (width == context_make_atom(ctx, bit_12_atom)) {
         return ADC_WIDTH_BIT_12;
     } else {
         return ADC_WIDTH_MAX;
@@ -98,6 +101,7 @@ static adc_bits_width_t get_width(Context *ctx, term width)
 static adc_unit_t adc_unit_from_pin(int pin_val)
 {
     switch (pin_val) {
+        #if CONFIG_IDF_TARGET_ESP32
         case 32:
         case 33:
         case 34:
@@ -106,8 +110,27 @@ static adc_unit_t adc_unit_from_pin(int pin_val)
         case 37:
         case 38:
         case 39:
+        #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+        #elif CONFIG_IDF_TARGET_ESP32C3
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+        case 4:
+        #endif
             return ADC_UNIT_1;
         #ifdef CONFIG_AVM_ADC2_ENABLE
+        #if CONFIG_IDF_TARGET_ESP32
         case 0:
         case 2:
         case 4:
@@ -118,6 +141,20 @@ static adc_unit_t adc_unit_from_pin(int pin_val)
         case 25:
         case 26:
         case 27:
+        #elif CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32S2
+        case 11:
+        case 12:
+        case 13:
+        case 14:
+        case 15:
+        case 16:
+        case 17:
+        case 18:
+        case 19:
+        case 20:
+        #elif CONFIG_IDF_TARGET_ESP32C3
+        case 5:
+        #endif
             return ADC_UNIT_2;
         #endif
         default:
@@ -132,7 +169,7 @@ static term nif_adc_config_width(Context *ctx, int argc, term argv[])
     term pin = argv[0];
     VALIDATE_VALUE(pin, term_is_integer);
     adc_unit_t adc_unit = adc_unit_from_pin(term_to_int(pin));
-    if (adc_unit == ADC_UNIT_MAX) {
+    if (UNLIKELY(adc_unit == ADC_UNIT_MAX)) {
         #ifdef ENABLE_TRACE
         int Pin = term_to_int(pin);
         #endif
@@ -202,6 +239,7 @@ static adc_atten_t get_attenuation(Context *ctx, term attenuation)
 static adc_channel_t get_channel(avm_int_t pin_val)
 {
     switch (pin_val) {
+        #if CONFIG_IDF_TARGET_ESP32
         case 32:
             return ADC1_CHANNEL_4;
         case 33:
@@ -218,7 +256,41 @@ static adc_channel_t get_channel(avm_int_t pin_val)
             return ADC1_CHANNEL_2;
         case 39:
             return ADC1_CHANNEL_3;
-        #ifdef CONFIG_AVM_ADC2_ENABLE
+        #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+        case 1:
+            return ADC1_CHANNEL_0;
+        case 2:
+            return ADC1_CHANNEL_1;
+        case 3:
+            return ADC1_CHANNEL_2;
+        case 4:
+            return ADC1_CHANNEL_3;
+        case 5:
+            return ADC1_CHANNEL_4;
+        case 6:
+            return ADC1_CHANNEL_5;
+        case 7:
+            return ADC1_CHANNEL_6;
+        case 8:
+            return ADC1_CHANNEL_7;
+        case 9:
+            return ADC1_CHANNEL_8;
+        case 10:
+            return ADC1_CHANNEL_9;
+        #elif CONFIG_IDF_TARGET_ESP32C3
+        case 0:
+            return ADC1_CHANNEL_0;
+        case 1:
+            return ADC1_CHANNEL_1;
+        case 2:
+            return ADC1_CHANNEL_2;
+        case 3:
+            return ADC1_CHANNEL_3;
+        case 4:
+            return ADC1_CHANNEL_4;
+        #endif
+    #ifdef CONFIG_AVM_ADC2_ENABLE
+        #if CONFIG_IDF_TARGET_ESP32
         case 0:
             return ADC2_CHANNEL_1;
         case 2:
@@ -239,7 +311,32 @@ static adc_channel_t get_channel(avm_int_t pin_val)
             return ADC2_CHANNEL_9;
         case 27:
             return ADC2_CHANNEL_7;
+        #elif CONFIG_IDF_TARGET_ESP32S2 || CONFIG_IDF_TARGET_ESP32S3
+        case 11:
+            return ADC2_CHANNEL_0;
+        case 12:
+            return ADC2_CHANNEL_1;
+        case 13:
+            return ADC2_CHANNEL_2;
+        case 14:
+            return ADC2_CHANNEL_3;
+        case 15:
+            return ADC2_CHANNEL_4;
+        case 16:
+            return ADC2_CHANNEL_5;
+        case 17:
+            return ADC2_CHANNEL_6;
+        case 18:
+            return ADC2_CHANNEL_7;
+        case 19:
+            return ADC2_CHANNEL_8;
+        case 20:
+            return ADC2_CHANNEL_9;
+        #elif CONFIG_IDF_TARGET_ESP32C3
+        case 5:
+            return ADC2_CHANNEL_0;
         #endif
+    #endif
         default:
             return ADC_CHANNEL_MAX;
     }

--- a/nifs/atomvm_adc.c
+++ b/nifs/atomvm_adc.c
@@ -228,6 +228,13 @@ static term nif_adc_take_reading(Context *ctx, int argc, term argv[])
         esp_adc_cal_characterize(ADC_UNIT_1, atten, bit_width, DEFAULT_VREF, adc_chars);
     log_char_val_type(val_type);
 
+    // adc1_config_width() is used here in case the last adc1 pin to be configured was of a different width.
+    // this will ensure the calibration characteristics and reading match the desired bit width for the channel.
+    esp_err_t err = adc1_config_width(bit_width);
+    if (err != ESP_OK) {
+        RAISE_ERROR(BADARG_ATOM);
+    }
+
     uint32_t adc_reading = 0;
     for (avm_int_t i = 0;  i < samples_val;  ++i) {
         adc_reading += adc1_get_raw((adc1_channel_t) channel);

--- a/src/adc.erl
+++ b/src/adc.erl
@@ -25,13 +25,15 @@
 -export([
     start/1, start/2, stop/1, read/1, read/2
 ]).
--export([config_width/1, config_channel_attenuation/2, take_reading/4]). %% internal nif APIs
+-export([config_width/2, config_channel_attenuation/2, take_reading/4]). %% internal nif APIs
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
 -behaviour(gen_server).
 
 -type adc() :: term().
--type adc_pin() :: 32..39.
+-type adc_pin() ::  adc1_pin() | adc2_pin().
+-type adc1_pin() :: 32..39.
+-type adc2_pin() :: 0 | 2 | 4 | 12..15 | 25..27.
 -type options() :: [option()].
 -type bit_width() :: bit_9 | bit_10 | bit_11 | bit_12.
 -type attenuation() :: db_0 | db_2_5 | db_6 | db_11.
@@ -142,7 +144,7 @@ read(ADC, ReadOptions) ->
 %% @hidden
 init([Pin, Options]) ->
     BitWidth = proplists:get_value(bit_width, Options, bit_12),
-    case adc:config_width(BitWidth) of
+    case adc:config_width(Pin, BitWidth) of
         ok -> ok;
         {error, R1} ->
             throw({config_width, R1})
@@ -185,7 +187,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%
 
 %% @hidden
-config_width(_BitWidth) ->
+config_width(_Pin, _BitWidth) ->
     throw(nif_error).
 
 %% @hidden


### PR DESCRIPTION
This set of changes enables the use of the adc2 unit on the esp32. Functions are provided to give the WiFi a temporary lock on the adc2 unit, for applications that require the use of both WiFi and adc2 for measurements.