### PR TITLE
Fix bug when using attenuation db_11

### DIFF
--- a/nifs/atomvm_adc.c
+++ b/nifs/atomvm_adc.c
@@ -61,7 +61,7 @@ static const AtomStringIntPair attenuation_table[] = {
     { ATOM_STR("\x4", "db_0"), ADC_ATTEN_DB_0 },
     { ATOM_STR("\x6", "db_2_5"), ADC_ATTEN_DB_2_5 },
     { ATOM_STR("\x4", "db_6"), ADC_ATTEN_DB_6 },
-    { ATOM_STR("\x6", "db_11"), ADC_ATTEN_DB_11 },
+    { ATOM_STR("\x5", "db_11"), ADC_ATTEN_DB_11 },
     SELECT_INT_DEFAULT(ADC_ATTEN_MAX)
 };
 

--- a/src/adc.erl
+++ b/src/adc.erl
@@ -158,7 +158,7 @@ init([Pin, Options]) ->
         {error, R1} ->
             throw({config_width, R1})
     end,
-    Attenuation = proplists:get_value(attenuation, Options, db_0),
+    Attenuation = proplists:get_value(attenuation, Options, db_11),
     case adc:config_channel_attenuation(Pin, Attenuation) of
         ok -> ok;
         {error, R2} ->


### PR DESCRIPTION
The lenght of the atom string for db_11 was incorrect, making it unusable. Changed default attenuation to db_11 as this falls closer to the voltage range available on gpio pins.

Closes #3